### PR TITLE
Chore/review-flow

### DIFF
--- a/api/endpoints/review.go
+++ b/api/endpoints/review.go
@@ -1,9 +1,11 @@
 package endpoints
 
 import (
+	"net/http"
+
+	"github.com/adraismawur/mibig-submission/models/entry"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"net/http"
 )
 
 func init() {
@@ -28,6 +30,13 @@ func ReviewEndpoint(db *gorm.DB) Endpoint {
 					postReview(db, c)
 				},
 			},
+			{
+				Method: "POST",
+				Path:   "/review/check",
+				Handler: func(c *gin.Context) {
+					checkReview(db, c)
+				},
+			},
 		},
 	}
 }
@@ -42,4 +51,42 @@ func postReview(db *gorm.DB, c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message": "post review",
 	})
+}
+
+type ReviewRequest struct {
+	Accession string         `json:"accession"`
+	Category  entry.Category `json:"category"`
+}
+
+func checkReview(db *gorm.DB, c *gin.Context) {
+	var request ReviewRequest
+
+	err := c.ShouldBindJSON(&request)
+
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var activeReview entry.SubmissionReview
+	err = db.
+		Table("submission_reviews").
+		Where("accession = $1 AND category = $2", request.Accession, request.Category).
+		Find(&activeReview).
+		Error
+
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	var response struct {
+		State entry.ReviewState `json:"state"`
+		User  uint64            `json:"user"`
+	}
+
+	response.State = activeReview.State
+	response.User = activeReview.UserID
+
+	c.JSON(http.StatusOK, response)
 }

--- a/web/submission/edit/views.py
+++ b/web/submission/edit/views.py
@@ -108,7 +108,7 @@ def edit_bgc_redirect(bgc_id: str):
     )
 
 
-def generate_wizard_page(bgc_id: str, form_id: str, show_nav: bool):
+def generate_wizard_page(bgc_id: str, form_id: str, show_nav: bool, active_review: bool):
     # instantiate associated form
     wizard_page = get_wizard_page(form_id)
 
@@ -170,7 +170,7 @@ def generate_wizard_page(bgc_id: str, form_id: str, show_nav: bool):
         wizard_page.template,
         form=form,
         bgc_id=bgc_id,
-        is_reviewer=current_user.has_role(Role.REVIEWER),
+        is_reviewer=active_review,
         reviewed=False,
         show_nav=show_nav,
         next_form=next_form,
@@ -202,7 +202,12 @@ def edit_bgc(bgc_id: str, form_id: str) -> Union[str, response.Response]:
 
     show_nav = lock_response.json()["full"]
 
-    return generate_wizard_page(bgc_id, form_id, show_nav)
+    # we already know the user owns the lock on this section so we can just check if 
+    # this entry is currently being reviewed by the user
+    review_response = Entry.check_review(bgc_id, form_id)
+    active_review = review_response.json()["state"] == "being reviewed"
+
+    return generate_wizard_page(bgc_id, form_id, show_nav, active_review)
 
 
 @bp_edit.route("/<bgc_id>/lock/request/<category>", methods=["GET", "POST"])

--- a/web/submission/edit/views.py
+++ b/web/submission/edit/views.py
@@ -108,7 +108,7 @@ def edit_bgc_redirect(bgc_id: str):
     )
 
 
-def generate_wizard_page(bgc_id: str, form_id: str, show_nav: bool, active_review: bool):
+def generate_wizard_page(bgc_id: str, form_id: str, show_nav: bool, active_review: bool=False):
     # instantiate associated form
     wizard_page = get_wizard_page(form_id)
 
@@ -205,11 +205,12 @@ def edit_bgc(bgc_id: str, form_id: str) -> Union[str, response.Response]:
 
     # we already know the user owns the lock on this section so we can just check if 
     # this entry is currently being reviewed by the user
-    review_response = Entry.check_review(bgc_id, form_id)
-    active_review = review_response.json()["state"] == "being reviewed"
+    if current_user.has_role(Role.REVIEWER):
+        review_response = Entry.check_review(bgc_id, form_id)
+        active_review = review_response.json()["state"] == "being reviewed"
+        return generate_wizard_page(bgc_id, form_id, show_nav, active_review)
 
-    return generate_wizard_page(bgc_id, form_id, show_nav, active_review)
-
+    return generate_wizard_page(bgc_id, form_id, show_nav)
 
 @bp_edit.route("/<bgc_id>/lock/request/<category>", methods=["GET", "POST"])
 @login_required

--- a/web/submission/edit/views.py
+++ b/web/submission/edit/views.py
@@ -170,7 +170,7 @@ def generate_wizard_page(bgc_id: str, form_id: str, show_nav: bool, active_revie
         wizard_page.template,
         form=form,
         bgc_id=bgc_id,
-        is_reviewer=active_review,
+        is_reviewer=current_user.has_role(Role.REVIEWER),
         reviewed=False,
         show_nav=show_nav,
         next_form=next_form,
@@ -179,6 +179,7 @@ def generate_wizard_page(bgc_id: str, form_id: str, show_nav: bool, active_revie
         antismash_json_url=antismash_json_url,
         antismash_json=antismash_json,
         antismash_accessions=antismash_accessions,
+        active_review=active_review,
     )
 
 

--- a/web/submission/models/entries.py
+++ b/web/submission/models/entries.py
@@ -679,6 +679,19 @@ class Entry(db.Model):
 
         return response
 
+    def check_review(bgc_id, category):
+        review_endpoint = "/review/check/"
+        response = requests.post(
+            f"{current_app.config['API_BASE']}" + review_endpoint,
+            headers={"Authorization": f"Bearer {session['token']}"},
+            json={
+                "accession": bgc_id,
+                "category": category,
+            },
+        )
+        return response
+
+
     def request_lock(bgc_id: str, category: str):
         lock_endpoint = "/lock/request/"
         response = requests.post(

--- a/web/submission/templates/edit/view_json.html
+++ b/web/submission/templates/edit/view_json.html
@@ -11,9 +11,9 @@
                 <button class="btn btn-primary">Back to submission overview</button>
             </a>
         {% endif %}
-        <a href="{{ url_for('edit.edit_bgc', bgc_id=bgc_id, form_id='locitax') }}">
+        <!-- <a href="{{ url_for('edit.edit_bgc', bgc_id=bgc_id, form_id='locitax') }}">
             <button class="btn btn-primary">Edit this entry/submission</button>
-        </a>
+        </a> -->
         <div class="form-group subgroup">
            <span style="white-space: pre-wrap;">
                 {{ entry }}

--- a/web/submission/templates/macros.html
+++ b/web/submission/templates/macros.html
@@ -1,17 +1,17 @@
-{% macro simple_divform(form, is_reviewer=false, reviewed=false) %}
+{% macro simple_divform(form) %}
 <form method="post" class="">
-    {{ simple_divform_inner(form, is_reviewer, reviewed) }}
+    {{ simple_divform_inner(form) }}
 </form>
 {% endmacro %}
 
-{% macro simple_divform_inner(form, is_reviewer=false, reviewed=false ) %}
+{% macro simple_divform_inner(form) %}
 <fieldset>
     {% for field in form %}
     {% if field.type == "HiddenField" or field.widget.input_type == "hidden"%}
     {{field}}
     {% else %}
     <div id="{{ field.id }}" class="form-group">
-        {{ render_field(field, is_reviewer, reviewed) }}
+        {{ render_field(field) }}
     </div>
     {% endif %}
     {% endfor %}
@@ -20,7 +20,7 @@
 {% endmacro %}
 
 
-{% macro render_field(field, is_reviewer=false, reviewed=false) %}
+{% macro render_field(field) %}
 
 {% set is_required = " fw-bold" %}
 {% set ns = namespace(delete=true) %}
@@ -31,15 +31,6 @@
 
 {% if field.type == 'SubmitField' %}
 <div>
-    {% if is_reviewer %}
-    {% set is_reviewed = "checked" if reviewed else "" %}
-    <!-- <div class="form-group" style="background-color: var(--mibig-light)">
-        <label class="form-label fw-bold" for="reviewed">Mark as reviewed</label>
-        <input id="reviewed" name="reviewed" class="form-check-input" type="checkbox" value="yes" {{is_reviewed}}>
-        <p class="form-text text-muted">Visible to reviewers only, please check this box only when reviewing <u>a
-                colleague's</u> submission</p>
-    </div> -->
-    {% endif %}
 
     {{ field(class='btn btn-light')}}
 </div>
@@ -316,7 +307,7 @@
 
         {% endmacro %}
 
-        {% macro render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=True) %}
+        {% macro render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=True, is_reviewer=False) %}
         {% if show_save %}
         <div class="row">
             <div class="col s12">
@@ -335,11 +326,19 @@
                 {%- endif %}
             </div>
             <div class="col s4 center-align">
+                {% if is_reviewer %}
+                <a href="{{ url_for('review.list_submissions') }}">
+                    <button id="back-btn" class="btn btn-secondary btn-large btn-nav" type="button">
+                        Back to review overview
+                    </button>
+                </a>
+                {% else %}
                 <a href="{{ url_for('edit.edit_bgc_redirect', bgc_id=bgc_id) }}">
                     <button id="back-btn" class="btn btn-secondary btn-large btn-nav" type="button">
                         Back to edit overview
                     </button>
                 </a>
+                {% endif %}
             </div>
             <div class="col s4 center-align">
                 {% if show_nav and next_form %}

--- a/web/submission/templates/macros.html
+++ b/web/submission/templates/macros.html
@@ -1,17 +1,17 @@
-{% macro simple_divform(form) %}
+{% macro simple_divform(form, is_reviewer=false, reviewed=false) %}
 <form method="post" class="">
-    {{ simple_divform_inner(form) }}
+    {{ simple_divform_inner(form, is_reviewer, reviewed) }}
 </form>
 {% endmacro %}
 
-{% macro simple_divform_inner(form) %}
+{% macro simple_divform_inner(form, is_reviewer=false, reviewed=false ) %}
 <fieldset>
     {% for field in form %}
     {% if field.type == "HiddenField" or field.widget.input_type == "hidden"%}
     {{field}}
     {% else %}
     <div id="{{ field.id }}" class="form-group">
-        {{ render_field(field) }}
+        {{ render_field(field, is_reviewer, reviewed) }}
     </div>
     {% endif %}
     {% endfor %}
@@ -20,7 +20,7 @@
 {% endmacro %}
 
 
-{% macro render_field(field) %}
+{% macro render_field(field, is_reviewer=false, reviewed=false) %}
 
 {% set is_required = " fw-bold" %}
 {% set ns = namespace(delete=true) %}
@@ -31,6 +31,15 @@
 
 {% if field.type == 'SubmitField' %}
 <div>
+    {% if is_reviewer %}
+    {% set is_reviewed = "checked" if reviewed else "" %}
+    <!-- <div class="form-group" style="background-color: var(--mibig-light)">
+        <label class="form-label fw-bold" for="reviewed">Mark as reviewed</label>
+        <input id="reviewed" name="reviewed" class="form-check-input" type="checkbox" value="yes" {{is_reviewed}}>
+        <p class="form-text text-muted">Visible to reviewers only, please check this box only when reviewing <u>a
+                colleague's</u> submission</p>
+    </div> -->
+    {% endif %}
 
     {{ field(class='btn btn-light')}}
 </div>
@@ -307,7 +316,7 @@
 
         {% endmacro %}
 
-        {% macro render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=True, is_reviewer=False) %}
+        {% macro render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=True, active_review=False) %}
         {% if show_save %}
         <div class="row">
             <div class="col s12">
@@ -326,7 +335,7 @@
                 {%- endif %}
             </div>
             <div class="col s4 center-align">
-                {% if is_reviewer %}
+                {% if active_review %}
                 <a href="{{ url_for('review.list_submissions') }}">
                     <button id="back-btn" class="btn btn-secondary btn-large btn-nav" type="button">
                         Back to review overview

--- a/web/submission/templates/wizard/biosynth.html
+++ b/web/submission/templates/wizard/biosynth.html
@@ -174,7 +174,7 @@ Editing {{ bgc_id }}
     </div>
 
     <div class="form-group">
-        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False)}}
+        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False, is_reviewer=is_reviewer)}}
     </div>
 
 

--- a/web/submission/templates/wizard/biosynth.html
+++ b/web/submission/templates/wizard/biosynth.html
@@ -174,7 +174,8 @@ Editing {{ bgc_id }}
     </div>
 
     <div class="form-group">
-        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False, is_reviewer=is_reviewer)}}
+        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False,
+        active_review=active_review)}}
     </div>
 
 

--- a/web/submission/templates/wizard/compounds.html
+++ b/web/submission/templates/wizard/compounds.html
@@ -67,7 +67,8 @@ Editing {{ bgc_id }}
         </div>
     </div>
     <div class="form-group">
-        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False, is_reviewer=is_reviewer)}}
+        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False,
+        active_review=active_review)}}
     </div>
 
 </div>

--- a/web/submission/templates/wizard/compounds.html
+++ b/web/submission/templates/wizard/compounds.html
@@ -67,7 +67,7 @@ Editing {{ bgc_id }}
         </div>
     </div>
     <div class="form-group">
-        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False)}}
+        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False, is_reviewer=is_reviewer)}}
     </div>
 
 </div>

--- a/web/submission/templates/wizard/gene_information.html
+++ b/web/submission/templates/wizard/gene_information.html
@@ -129,7 +129,8 @@ Editing {{ bgc_id }}
 
 
     <div class="form-group">
-        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False, is_reviewer=is_reviewer)}}
+        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False,
+        active_review=active_review)}}
     </div>
 </div>
 

--- a/web/submission/templates/wizard/gene_information.html
+++ b/web/submission/templates/wizard/gene_information.html
@@ -129,7 +129,7 @@ Editing {{ bgc_id }}
 
 
     <div class="form-group">
-        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False)}}
+        {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, show_save=False, is_reviewer=is_reviewer)}}
     </div>
 </div>
 

--- a/web/submission/templates/wizard/main.html
+++ b/web/submission/templates/wizard/main.html
@@ -19,7 +19,7 @@ Editing {{ bgc_id }}
         {{ macros.simple_divform_inner(form) }}
 
         <div class=" form-group">
-            {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, is_reviewer=is_reviewer)}}
+            {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, active_review=active_review)}}
         </div>
     </form>
 </div>

--- a/web/submission/templates/wizard/main.html
+++ b/web/submission/templates/wizard/main.html
@@ -16,10 +16,10 @@ Editing {{ bgc_id }}
     <h4>Enter {{ form_description }}</h4>
 
     <form method="post">
-        {{ macros.simple_divform_inner(form, is_reviewer=is_reviewer, reviewed=reviewed) }}
+        {{ macros.simple_divform_inner(form) }}
 
         <div class=" form-group">
-            {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form)}}
+            {{ macros.render_wizard_nav(show_nav, bgc_id, prev_form, next_form, is_reviewer=is_reviewer)}}
         </div>
     </form>
 </div>


### PR DESCRIPTION
Whenever you open an 'edit' page, backend checks locks to see if current user owns the lock. Added another check afterwards to see if the current user is the reviewer of the section -> if so change the shown button. 

Also disabled the 'edit entry' button from the json view, unable to navigate to the correct section currently.